### PR TITLE
Calva start fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Use the `cider` alias for CIDER nREPL support (run `clj -M:dev:cider`). See the 
 
 Note that this alias runs nREPL during development. To run nREPL in production (typically when the system starts), use the kit-nrepl library through the +nrepl profile as described in [the documentation](https://kit-clj.github.io/docs/profiles.html#profiles).
 
+### Calva (VS Code)
+
+Easiest is to use the command **Calva: Start a Project REPL and Connect** (a.k.a. Jack-in)** and select the `:dev` alias. See [Calva docs](https://calva.io) for how to use Calva.
+
+If you prefer to start the REPL manually, you can run `clj -M:dev:cider` and then connect Calva.
+
 ### Command Line
 
 Run `clj -M:dev:nrepl` or `make repl`.

--- a/deps.edn
+++ b/deps.edn
@@ -39,8 +39,7 @@
                                 ring/ring-mock                  {:mvn/version "0.4.0"}
                                 io.github.kit-clj/kit-generator {:mvn/version "0.1.3"}
                                 org.clojure/tools.namespace     {:mvn/version "1.2.0"}}
-                  :extra-paths ["env/dev/clj" "env/dev/resources" "test/clj" "target/classes/cljsbuild"]
-                  :main-opts   []}
+                  :extra-paths ["env/dev/clj" "env/dev/resources" "test/clj" "target/classes/cljsbuild"]}
            :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
                    :main-opts  ["-m" "nrepl.cmdline" "-i"]}
            :cider {:extra-deps {nrepl/nrepl       {:mvn/version "0.9.0"}


### PR DESCRIPTION
I've removed the empty `:dev :main-opts` entry as Calva is stupid about it and fails to run the main function it needs when this option is empty.

Also added a section to the README about how to get going using Calva.

Fixes: https://github.com/kit-clj/kit-clj.github.io/issues/32